### PR TITLE
Feature/issue 9: Adds ExtractDecimal method

### DIFF
--- a/pipeline_components/data_cleaning.py
+++ b/pipeline_components/data_cleaning.py
@@ -253,3 +253,87 @@ class ReplaceStartWithFn(beam.DoFn):
                     # If so, replace the prefix with 'replace_with'. This specifically handles removing the prefix correctly.
                     element[column] = self.replace_with + element[column][len(self.start_with):]
         yield element
+
+
+class ExtractDecimalFn(beam.DoFn):
+    """
+    A custom Apache Beam transformation to extract decimal values from one or more fields in an element.
+
+    Args:
+        columns: A list of column names to be processed.
+    """
+
+    def process(self, element, *columns):
+        """
+        Processes an element, extracts decimal values from the specified fields, and replaces them with the extracted values.
+
+        Args:
+            element: The element to be processed.
+            *columns: Variable arguments containing the names of the columns to be processed.
+
+        Yields:
+            A new element with the extracted decimal values.
+        """
+
+        for column in columns:
+            if column in element:
+                input_string = element[column]
+                cleaned_value = self.extract_decimal(input_string)
+                if cleaned_value is not None:
+                    element[column] = cleaned_value
+        yield element
+
+    def extract_decimal(self, input_string):
+        """
+        Extracts a decimal value from an input string.
+
+        Args:
+            input_string: The input string to be processed.
+
+        Returns:
+            A Decimal object representing the extracted value, or None if extraction fails.
+        """
+
+        # Handle negative values enclosed in parentheses using regex
+        cleaned_string = re.sub(r'\((.*?)\)', lambda x: '-' + x.group(1), input_string)
+        # Replace all non-numeric characters except commas and minus signs with an empty string
+        cleaned_string = re.sub(r'[^\d,-]', '', cleaned_string).replace(',', '.')
+        try:
+            # Convert the cleaned string to a Decimal without rounding
+            return Decimal(cleaned_string)
+        except InvalidOperation:
+            # If conversion to Decimal fails, print an error message and return None
+            print(f"Invalid value: {input_string} got {cleaned_string}")
+            return None
+
+    """
+    Usage Examples:
+    - Extracting decimal values from a dataset:
+        pipeline = beam.Pipeline()
+        data = [{'amount': '$1,234.56'}, {'amount': '(1,500.25)'}]
+        extracted_data = (
+            pipeline
+            | 'Create Data' >> beam.Create(data)
+            | 'Extract Decimals' >> beam.ParDo(ExtractDecimalFn(), 'amount')
+            | beam.Map(print)
+        )
+        pipeline.run()
+
+    - Extracting and cleaning monetary values:
+        pipeline = beam.Pipeline()
+        data = [{'amount': '$1.234,56'}, {'amount': '(1.500,25)'}]
+        cleaned_data = (
+            pipeline
+            | 'Create Data' >> beam.Create(data)
+            | 'Extract Decimals' >> beam.ParDo(ExtractDecimalFn(), 'amount')
+            | beam.Filter(lambda x: x['amount'] is not None)  # Filtering out invalid values
+            | beam.Map(lambda x: {'cleaned_amount': x['amount']})  # Optionally, store cleaned values in a new field
+            | beam.Map(print)
+        )
+        pipeline.run()
+
+    Notes:
+    - This method is particularly useful for handling monetary values, as it avoids rounding discrepancies.
+    - It extracts decimal values from input strings, including cases where negative values are represented within parentheses.
+    - If decimal values are already separeted by dots, please try a simple cast to Decimal Type. 
+    """

--- a/pipeline_components/data_cleaning.py
+++ b/pipeline_components/data_cleaning.py
@@ -1,4 +1,6 @@
 import apache_beam as beam
+import re
+from decimal import Decimal, InvalidOperation
 
 class ChangeDateFormat(beam.DoFn):
     def __init__(self, date_columns, input_format, output_format='%Y-%m-%d'):
@@ -302,9 +304,8 @@ class ExtractDecimalFn(beam.DoFn):
             # Convert the cleaned string to a Decimal without rounding
             return Decimal(cleaned_string)
         except InvalidOperation:
-            # If conversion to Decimal fails, print an error message and return None
-            print(f"Invalid value: {input_string} got {cleaned_string}")
-            return None
+            # If conversion to Decimal fails, raise an error message and return None
+            raise ValueError(f"Invalid value: {input_string} (cleaned: {cleaned_string})")
 
     """
     Usage Examples:


### PR DESCRIPTION
**Resolve issue #9** 

Esta PR introduz melhorias na classe ExtractDecimalFn, uma transformação personalizada do Apache Beam, que permite extrair valores decimais de um ou mais campos em um elemento. As melhorias incluem:

**Tratamento aprimorado de exceções:** Atualizei a função extract_decimal para lançar uma exceção ValueError ao invés de apenas imprimir uma mensagem de erro, quando a conversão para Decimal falha. Isso torna o tratamento de erros mais robusto e fornece mensagens de erro mais úteis para os usuários.

**Uso de exceções específicas:** Substituí a captura genérica de exceções por uma captura específica de InvalidOperation, utilizando a exceção ValueError. Isso melhora a clareza do código e torna mais fácil para os usuários entenderem o motivo exato do erro.

**Adição de exemplos de tipos de dados limpos:** Adicionei exemplos ao comentário de documentação da classe para demonstrar os tipos de dados que a classe limpa antes de transformá-los em decimal. Isso ajuda os usuários a entenderem melhor como usar a transformação e quais formatos de dados são suportados.

Essas melhorias visam tornar a classe ExtractDecimalFn mais confiável, robusta e fácil de usar para os usuários, proporcionando um tratamento de exceções mais consistente, mensagens de erro mais úteis e exemplos claros de uso.

Por favor, revise e comente sobre as mudanças propostas. Estou aberto a qualquer feedback ou sugestão adicional.