### PR TITLE
Compatibilidade com Python 3.12 e flexibilização das dependências

### DIFF
--- a/.github/workflows/tests_requirements.txt
+++ b/.github/workflows/tests_requirements.txt
@@ -1,2 +1,5 @@
 pytest
-apache-beam[gcp]
+apache-beam[gcp]>=2.61.0
+pandas>=2.1.0
+openpyxl>=3.0.0
+pytz>=2021.3

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,9 @@ setup(
     version='3.0.0',
     packages=find_packages(),
     install_requires=[
-        'apache-beam[dataframe,gcp,interactive]==2.64.0',
-        'pandas==2.0.3',
-        'numpy==1.26.3',
-        'pytz==2025.2',
-        'openpyxl==3.1.5'
+        'apache-beam[dataframe,gcp,interactive]>=2.61.0',  # 2.61+ added Python 3.12 support
+        'pandas>=2.1.0',                                   # 2.1+ has Python 3.12 wheels
+        'pytz>=2021.3',
+        'openpyxl>=3.0.0',
     ],
 )


### PR DESCRIPTION
## Descrição:

Corrige a instalação do pacote em ambientes Python 3.12+, mantendo compatibilidade com Python 3.10 e 3.11.

## Mudanças:

* setup.py: substituídas versões exatas (==) por versões mínimas (>=) em todas as dependências; removido numpy (não é importado em nenhum arquivo fonte);
* pandas==2.0.3 → pandas>=2.1.0: versão 2.0.3 não possui wheel pré-compilada para Python 3.12, causando falha na instalação;
* apache-beam==2.64.0 → apache-beam>=2.61.0: versão 2.61.0 foi a primeira com suporte oficial ao Python 3.12; pins exatos em bibliotecas causam conflitos para quem consome o pacote;
* tests_requirements.txt: adicionados pandas, openpyxl e pytz que estavam ausentes no ambiente de CI;
* unit_tests.yml: matriz de testes expandida para ["3.10", "3.11", "3.12"]